### PR TITLE
Use nvcc compiler version

### DIFF
--- a/recipes/nccl/conda_build_config.yaml
+++ b/recipes/nccl/conda_build_config.yaml
@@ -1,2 +1,4 @@
 nvcc_compiler:
 - nvcc
+nvcc_compiler_version:
+- {{ environ.get('CUDA', '9.2') }}

--- a/recipes/nccl/meta.yaml
+++ b/recipes/nccl/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "nccl" %}
 {% set version = "2.4.6" %}
 {% set revision = "1" %}
-{% set cuda_version = environ.get('CUDA', '9.2') %}
 
 package:
   name: {{ name|lower }}
@@ -16,7 +15,6 @@ source:
 build:
   number: 0
   skip: true  # [not linux]
-  string: cuda{{ cuda_version }}_0
   run_exports:
     # xref: https://github.com/NVIDIA/nccl/issues/218
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -25,10 +23,10 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - {{ compiler("nvcc") }} {{ cuda_version }}
+    - {{ compiler("nvcc") }}
     - make
   host:
-    - cudatoolkit {{ cuda_version }}
+    - cudatoolkit
 
 test:
   commands:

--- a/recipes/xgboost/conda_build_config.yaml
+++ b/recipes/xgboost/conda_build_config.yaml
@@ -3,3 +3,5 @@ xgboost_proc_type:
 - gpu
 nvcc_compiler:
 - nvcc
+nvcc_compiler_version:
+- {{ environ.get('CUDA', '9.2') }}

--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "xgboost" %}
 {% set xgboost_version = environ.get('XGBOOST_VERSION', '0.90.rapidsdev1') %}
-{% set cuda_version = environ.get('CUDA', '9.2') %}
 {% set py_version=environ.get('CONDA_PY', '36') %}
 
 package:
@@ -26,13 +25,13 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ compiler('nvcc') }} {{ cuda_version }}         # [xgboost_proc_type == "gpu"]
+    - {{ compiler('nvcc') }}         # [xgboost_proc_type == "gpu"]
     - git
     - cmake
     - make
     - llvm-openmp >=4.0.1  # [osx]
   host:
-    - cudatoolkit {{ cuda_version }}
+    - cudatoolkit
     - libcudf >=0.7 # [xgboost_proc_type == "gpu"]
     - nccl 2.*             # [xgboost_proc_type == "gpu"]
     - llvm-openmp >=4.0.1  # [osx]
@@ -53,7 +52,6 @@ outputs:
   - name: libxgboost
     script: install-libxgboost.sh
     build:
-      string: cuda{{ cuda_version }}_1
       ignore_run_exports:
         - libcudf
     requirements:
@@ -77,7 +75,6 @@ outputs:
   - name: py-xgboost
     script: install-py-xgboost.sh
     build:
-      string: cuda{{ cuda_version }}py{{ py_version }}_1
       ignore_run_exports:
         - nvcc
     requirements:
@@ -119,7 +116,6 @@ outputs:
 
   - name: xgboost
     build:
-      string: cuda{{ cuda_version }}py{{ py_version }}_1
     requirements:
       host:
         - python


### PR DESCRIPTION
Now uses the `nvcc_compiler_version` variant to constrain the version of `nvcc` used. As a result this gets added properly the package hash meaning we no longer need to hack the package string to include this.