### PR TITLE
Update `conda` environment name for CI

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -11,7 +11,8 @@ fi
 # install gpuci tools
 curl -s https://raw.githubusercontent.com/rapidsai/gpuci-mgmt/main/gpuci-tools.sh | bash
 
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 # load gpuci tools
 source ~/.bashrc


### PR DESCRIPTION
The `gdf` conda environment has been replaced with the `rapids` environment. A symlink was put in place for `gdf` to continue to work, but the symlink will be removed in the near future. This PR updates all scripts to use the `rapids` environment name.
