### PR TITLE
update cuda to 11.5

### DIFF
--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set xgboost_version = environ.get('XGBOOST_VERSION', '0.90.rapidsdev1') + environ.get('VERSION_SUFFIX', '') %}
-{% set cuda_version = environ.get('CUDA', '10.0') %}
+{% set cuda_version = environ.get('CUDA', '11.5') %}
 {% set py_version=environ.get('CONDA_PY', '36') %}
 {% set xgboost_repo = environ.get('XGBOOST_REPO', 'dmlc/xgboost') %}
 {% set xgboost_branch = environ.get('XGBOOST_BRANCH', 'main') %}


### PR DESCRIPTION
Update cuda to version 11.5 to add cuda enhanced capability to xgboost-conda build.