### PR TITLE
Remove duplicate `py-xgboost` package

### DIFF
--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -137,22 +137,6 @@ outputs:
       imports:
         - xgboost
 
-  - name: py-xgboost
-    build:
-      ignore_run_exports_from:
-        - nvcc_linux-64 # [linux64]
-        - nvcc_linux-aarch64 # [aarch64]
-    requirements:
-      host:
-        - python
-        - nccl >=2.5             # [xgboost_proc_type == "gpu"]
-      run:
-        - python
-        - {{ pin_subpackage('py-xgboost', exact=True) }}
-        - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
-      run_constrained:
-        - xgboost-proc * {{ xgboost_proc_type }}
-
   - name: xgboost
     build:
       string: cuda_{{ cuda_major }}_py{{ py_version }}_{{ build_number }}


### PR DESCRIPTION
This PR removes a duplicate `py-xgboost` package entry from the `outputs` section of the recipe. It seems that this entry is not the one that's being published to Anaconda.org, so it should be safe to remove.