### PR TITLE
Remove compiler vars from recipe

### DIFF
--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -24,9 +24,6 @@ build:
   number: 2
   skip: true  # [win or linux32]
   script_env:
-    - CC
-    - CXX
-    - CUDAHOSTCXX
     - XGBOOST_VERSION
     - XGBOOST_REPO
     - XGBOOST_BRANCH


### PR DESCRIPTION
`xgboost` is already configured to use `conda` compilers (i.e. see [here](https://github.com/rapidsai/xgboost-conda/blob/branch-22.06/recipes/xgboost/meta.yaml#L42-L45)). Therefore these variables are extraneous and can be removed.

The latest successful build log below confirms that conda compilers are being used during builds instead of our custom compilers, so these variables are extraneous and safe to remove.

- log - https://gpuci.gpuopenanalytics.com/job/rapidsai/job/conda/job/xgboost/job/xgboost-conda-build/283/CUDA=11.5,PYTHON=3.8/consoleText


![image](https://user-images.githubusercontent.com/7400326/172236129-feb7e025-bb61-40b3-90d6-4980de007dc2.png)
