### PR TITLE
Drop `cuda_compiler_version` from cbc

### DIFF
--- a/recipes/xgboost/conda_build_config.yaml
+++ b/recipes/xgboost/conda_build_config.yaml
@@ -3,8 +3,6 @@ xgboost_proc_type:
   - gpu
 cuda_compiler:
   - nvcc
-cuda_compiler_version:
-  - 11.5
 c_compiler:
   - gcc                        # [linux]
 c_compiler_version:            # [unix]


### PR DESCRIPTION
Adding `cuda_compiler_version` to `conda_build_config.yaml` duplicated what was already set in `meta.yaml`, which resulted in the version and build number being specified for `nvcc`. The latter just being the version number again, which resulted in solver issues (`nvcc_linux-64=11.5=11.5` does not exist). Drop `cuda_compiler_version` from `conda_build_config.yaml` to avoid this duplication and fix these build issues.