### PR TITLE
[WIP] Use `conda mambabuild`

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -17,9 +17,6 @@ conda activate rapids
 # load gpuci tools
 source ~/.bashrc
 
-#conda build -c conda-forge -c defaults recipes/nvcc
-#conda build -c ${NVIDIA_CONDA_USERNAME:-nvidia} -c conda-forge -c defaults recipes/nccl
-
 conda build -c ${CONDA_USERNAME:-rapidsai} -c ${NVIDIA_CONDA_USERNAME:-nvidia} -c conda-forge --python=$PYTHON  \
     recipes/xgboost
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -14,13 +14,16 @@ curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh |
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
+# Install `boa` for `mambabuild`
+conda install -yq boa
+
 # load gpuci tools
 source ~/.bashrc
 
-conda build -c ${CONDA_USERNAME:-rapidsai} -c ${NVIDIA_CONDA_USERNAME:-nvidia} -c conda-forge --python=$PYTHON  \
+conda mambabuild -c ${CONDA_USERNAME:-rapidsai} -c ${NVIDIA_CONDA_USERNAME:-nvidia} -c conda-forge --python=$PYTHON  \
     recipes/xgboost
 
-conda build -c ${CONDA_USERNAME:-rapidsai} -c ${NVIDIA_CONDA_USERNAME:-nvidia} -c conda-forge --python=$PYTHON  \
+conda mambabuild -c ${CONDA_USERNAME:-rapidsai} -c ${NVIDIA_CONDA_USERNAME:-nvidia} -c conda-forge --python=$PYTHON  \
     recipes/xgboost --output > $WORKSPACE/conda-output
 
 while read line ; do


### PR DESCRIPTION
Switch to using `conda mambabuild` to build the `xgboost` packages. Hopefully this speeds things up a bit.