### PR TITLE
Hotfix for release 1.6.2

### DIFF
--- a/recipes/xgboost/xgboost_master.patch
+++ b/recipes/xgboost/xgboost_master.patch
@@ -1,26 +1,16 @@
-From e2429a0c6e51f0c1d81ba0cedc8917539696ef68 Mon Sep 17 00:00:00 2001
-From: John Kirkham <jakirkham@gmail.com>
-Date: Tue, 21 Jun 2022 19:43:10 -0700
-Subject: [PATCH] Apply RAPIDS patch
-
----
- python-package/setup.py | 7 -------
- 1 file changed, 7 deletions(-)
-
 diff --git a/python-package/setup.py b/python-package/setup.py
-index 93f36de7b2..00a24e1fe5 100644
+index c2e6fd994..14aa3d543 100644
 --- a/python-package/setup.py
 +++ b/python-package/setup.py
-@@ -337,13 +337,6 @@ def run(self) -> None:
+@@ -280,12 +280,6 @@ if __name__ == '__main__':
                'scipy',
            ],
            ext_modules=[CMakeExtension('libxgboost')],
--          # error: expected "str": "Type[Command]"
 -          cmdclass={
--              'build_ext': BuildExt,     # type: ignore
--              'sdist': Sdist,            # type: ignore
--              'install_lib': InstallLib,  # type: ignore
--              'install': Install          # type: ignore
+-              'build_ext': BuildExt,
+-              'sdist': Sdist,
+-              'install_lib': InstallLib,
+-              'install': Install
 -          },
            extras_require={
                'pandas': ['pandas'],


### PR DESCRIPTION
This reverts [this commit](https://github.com/rapidsai/xgboost-conda/commit/009b5033e1a32be0dc08022d4a65b6c5062ac68b) and implements a fix for the failing 1.6.2 release job [here](https://gpuci.gpuopenanalytics.com/job/rapidsai/job/conda/job/xgboost/job/xgboost-conda-build/CUDA=11.5,PYTHON=3.8/306/console).