### PR TITLE
Fix builds

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -22,15 +22,19 @@ conda list --show-channel-urls
 export RAPIDS_CONDA_BLD_ROOT_DIR='/tmp/conda-bld-workspace'
 export RAPIDS_CONDA_BLD_OUTPUT_DIR='/tmp/conda-bld-output'
 
-env  | sort
+env | sort
 
 conda mambabuild \
   --python=$PYTHON \
   --croot=$RAPIDS_CONDA_BLD_ROOT_DIR \
   --output-folder=$RAPIDS_CONDA_BLD_OUTPUT_DIR \
+  --no-test \
   recipes/xgboost
 
 PKGS_TO_UPLOAD=$(find "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" -name "*.tar.bz2")
+PY_XGBOOST_PKG=$(echo "$PKGS_TO_UPLOAD" | grep "py-xgboost")
+
+conda build --test "${PY_XGBOOST_PKG}"
 
 gpuci_retry anaconda \
   -t ${MY_UPLOAD_KEY} \

--- a/build_all.sh
+++ b/build_all.sh
@@ -9,17 +9,12 @@ if [ -z "$XGBOOST_VERSION" ]; then
     exit 1
 fi
 
-# install gpuci tools
-curl -s https://raw.githubusercontent.com/rapidsai/gpuci-tools/main/install.sh | bash
-
 . /opt/conda/etc/profile.d/conda.sh
 conda activate rapids
 
 # Install `boa` for `mambabuild`
 conda install -yq boa
 
-# load gpuci tools
-source ~/.bashrc
 
 export RAPIDS_CONDA_BLD_ROOT_DIR='/tmp/conda-bld-workspace'
 export RAPIDS_CONDA_BLD_OUTPUT_DIR='/tmp/conda-bld-output'

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ex
 
 export PATH=/conda/bin:/usr/local/cuda/bin:$PATH
 export HOME=$WORKSPACE

--- a/build_all.sh
+++ b/build_all.sh
@@ -24,6 +24,10 @@ export RAPIDS_CONDA_BLD_OUTPUT_DIR='/tmp/conda-bld-output'
 
 env | sort
 
+
+# TODO: Figure out why the build fails without the `--no-test` flag.
+# Once that flag is removed, we can also remove the `conda build --test`
+# line below.
 conda mambabuild \
   --python=$PYTHON \
   --croot=$RAPIDS_CONDA_BLD_ROOT_DIR \

--- a/build_all.sh
+++ b/build_all.sh
@@ -13,8 +13,11 @@ fi
 conda activate rapids
 
 # Install `boa` for `mambabuild`
-conda install -yq boa
+mamba install -y boa
 
+conda info
+conda config --show-sources
+conda list --show-channel-urls
 
 export RAPIDS_CONDA_BLD_ROOT_DIR='/tmp/conda-bld-workspace'
 export RAPIDS_CONDA_BLD_OUTPUT_DIR='/tmp/conda-bld-output'


### PR DESCRIPTION
This PR includes some updates to our `xgboost` build scripts to account for the issue described below.

A Jenkins log displaying this error can be seen here: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/conda/job/xgboost/job/xgboost-conda-build/328/CUDA=11.5,PYTHON=3.8/console

This issue was also reproducible locally.

---

For some reason, the `conda build` command currently fails very early on without the `--no-test` flag with an error message about not being able to find the locally built version of `py-xgboost`.

This error message seems to appear before the local `py-xgboost` package is actually built, leading me to think that it's a bug with `conda`.

For whatever reason, using the `--no-test` flag seems to get us past that error message.

To account for the `--no-test` flag being added, I added a step to manually test the `py-xgboost` package before it's uploaded.