### PR TITLE
Enable copy_prs for GitHub Actions.

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,4 +5,4 @@ auto_merger: false
 branch_checker: false
 label_checker: false
 release_drafter: false
-copy_prs: false
+copy_prs: true


### PR DESCRIPTION
Enabling `copy_prs` so that GitHub Actions can run. cc: @ajschmidt8