### PR TITLE
Bump build number

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,7 +11,7 @@ export RAPIDS_VERSION="23.02"
 export XGBOOST_GIT_REPO="https://github.com/rapidsai/xgboost"
 export XGBOOST_GIT_REF="branch-${RAPIDS_VERSION}"
 export XGBOOST_VERSION="1.7.1dev.rapidsai${RAPIDS_VERSION}"
-export XGBOOST_BUILD_NUMBER="1"
+export XGBOOST_BUILD_NUMBER="2"
 
 rapids-print-env
 


### PR DESCRIPTION
After #51 was merged, only the `3.10` packages were uploaded to Anaconda.org since `3.8`/`3.9` packages with the same build number/version already exist on Anaconda.org

This results in a mix of `3.8`/`3.9` packages that were built with `11.5` and `3.10` packages that were built with `11.8`.

To ensure that a fresh set of packages are uploaded which are all built with `11.8`, this PR bumps the build number for the `xgboost` packages.