### PR TITLE
Update `RAPIDS_VERSION` to `23.04`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -7,7 +7,7 @@ source rapids-env-update
 
 export CMAKE_GENERATOR=Ninja
 
-export RAPIDS_VERSION="23.02"
+export RAPIDS_VERSION="23.04"
 export XGBOOST_GIT_REPO="https://github.com/rapidsai/xgboost"
 export XGBOOST_GIT_REF="branch-${RAPIDS_VERSION}"
 export XGBOOST_VERSION="1.7.1dev.rapidsai${RAPIDS_VERSION}"


### PR DESCRIPTION
Just updating the `RAPIDS_VERSION` on `branch-23.04`.

I wonder if there is a better way to do this instead of manual updates when a new branch is cut?