### PR TITLE
Remove duplicate `librmm` runtime dependency

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,7 +11,7 @@ export RAPIDS_VERSION="23.04"
 export XGBOOST_GIT_REPO="https://github.com/rapidsai/xgboost"
 export XGBOOST_GIT_REF="branch-${RAPIDS_VERSION}"
 export XGBOOST_VERSION="1.7.1dev.rapidsai${RAPIDS_VERSION}"
-export XGBOOST_BUILD_NUMBER="2"
+export XGBOOST_BUILD_NUMBER="3"
 
 rapids-print-env
 

--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -59,6 +59,7 @@ outputs:
       string: cuda_{{ cuda_major }}_{{ build_number }}
       ignore_run_exports_from:
         - {{ compiler('cuda') }}
+        - librmm
     requirements:
       build:
         - {{ compiler('c') }}


### PR DESCRIPTION
Similarly to https://github.com/rapidsai/raft/pull/1264, this PR removes a duplicate `run` dependency on `librmm`.

The current packages on Anaconda.org have a dependency on the `librmm` packages with the old date string format which have been removed from the `main` label.

Additionally the PR increments the build number so that new packages are published as a result of this change.