### PR TITLE
Reduce error handling verbosity in CI tests scripts

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,7 +1,7 @@
 # This file controls which features from the `ops-bot` repository below are enabled.
 # - https://github.com/rapidsai/ops-bot
 
-auto_merger: false
+auto_merger: true
 branch_checker: false
 label_checker: false
 release_drafter: false

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,7 +11,7 @@ export RAPIDS_VERSION="23.02"
 export XGBOOST_GIT_REPO="https://github.com/rapidsai/xgboost"
 export XGBOOST_GIT_REF="branch-${RAPIDS_VERSION}"
 export XGBOOST_VERSION="1.7.1dev.rapidsai${RAPIDS_VERSION}"
-export XGBOOST_BUILD_NUMBER="1"
+export XGBOOST_BUILD_NUMBER="2"
 
 rapids-print-env
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -30,6 +30,13 @@ rapids-mamba-retry install \
 rapids-logger "Check GPU usage"
 nvidia-smi
 
+EXITCODE=0
+trap "EXITCODE=1" ERR
+set +e
+
 rapids-logger "Run xgboost test script"
 pushd recipes/xgboost
 python test-py-xgboost.py
+
+rapids-logger "Test script exiting with value: $EXITCODE"
+exit ${EXITCODE}


### PR DESCRIPTION
This PR adds a less verbose [trap method](https://github.com/rapidsai/cugraph/blob/f2b081075704aabc789603e14ce552eac3fbe692/ci/test.sh#L19), for error handling to help ensure that we capture all potential error codes in our test scripts, and works as follows:

- setting an environment variable, EXITCODE, with a default value of 0
- setting a trap statement triggered by ERR signals which will set EXITCODE=1 when any commands return a non-zero exit code

cc @ajschmidt8