### PR TITLE
Forward-merge branch-23.04 to branch-23.06

### DIFF
--- a/recipes/xgboost/conda_build_config.yaml
+++ b/recipes/xgboost/conda_build_config.yaml
@@ -6,8 +6,8 @@ cuda_compiler:
 c_compiler:
   - gcc                        # [linux]
 c_compiler_version:            # [unix]
-  - 7                          # [linux64 or aarch64]
+  - 11                         # [linux64 or aarch64]
 cxx_compiler:
   - gxx                        # [linux]
 cxx_compiler_version:          # [unix]
-  - 7                          # [linux64 or aarch64]
+  - 11                         # [linux64 or aarch64]


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.04` that creates a PR to keep `branch-23.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.